### PR TITLE
Add migrations for Django 1.7+

### DIFF
--- a/cabot_alert_email/migrations/0001_initial.py
+++ b/cabot_alert_email/migrations/0001_initial.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cabotapp', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='EmailAlert',
+            fields=[
+                ('alertplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cabotapp.AlertPlugin')),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=('cabotapp.alertplugin',),
+        ),
+    ]


### PR DESCRIPTION
Required for Django 1.7+.

Note: This is incompatible with Django 1.6 - South will detect the plugin as an app with migrations, but doesn't understand Django 1.7 migrations and will barf during `migrate`. Only merge when we're going ahead with the Django 1.11 migration.